### PR TITLE
使用 DI 作為 design to interface 的實踐

### DIFF
--- a/RPS-Game.xcodeproj/project.pbxproj
+++ b/RPS-Game.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		5EA00DC124ED67CC00640945 /* GameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EA00DBF24ED67CC00640945 /* GameViewController.swift */; };
 		5EA00DC224ED67CC00640945 /* GameViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5EA00DC024ED67CC00640945 /* GameViewController.xib */; };
 		5EA00DC424ED6AF200640945 /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EA00DC324ED6AF200640945 /* GameView.swift */; };
+		A7C0A9A22509BE1C00B18525 /* GameComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C0A9A12509BE1C00B18525 /* GameComposition.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +33,7 @@
 		5EA00DBF24ED67CC00640945 /* GameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameViewController.swift; sourceTree = "<group>"; };
 		5EA00DC024ED67CC00640945 /* GameViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GameViewController.xib; sourceTree = "<group>"; };
 		5EA00DC324ED6AF200640945 /* GameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameView.swift; sourceTree = "<group>"; };
+		A7C0A9A12509BE1C00B18525 /* GameComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameComposition.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -139,6 +141,7 @@
 				5E79FA7924EE0FD500AE7A15 /* Model */,
 				5E79FA7824EE0FC900AE7A15 /* View */,
 				5E79FA7A24EE0FDF00AE7A15 /* ViewModel */,
+				A7C0A9A12509BE1C00B18525 /* GameComposition.swift */,
 			);
 			path = Game;
 			sourceTree = "<group>";
@@ -221,6 +224,7 @@
 				5EA00DC424ED6AF200640945 /* GameView.swift in Sources */,
 				5EA00DAA24ED664800640945 /* SceneDelegate.swift in Sources */,
 				5E79FA7724EE054300AE7A15 /* GameViewModel.swift in Sources */,
+				A7C0A9A22509BE1C00B18525 /* GameComposition.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RPS-Game/Applications/Game/GameComposition.swift
+++ b/RPS-Game/Applications/Game/GameComposition.swift
@@ -1,0 +1,21 @@
+//
+//  GameComposition.swift
+//  RPS-Game
+//
+//  Created by 游宗諭 on 2020/9/10.
+//  Copyright © 2020 Jeremy Xue. All rights reserved.
+//
+
+import Foundation
+struct GameComposition {
+    typealias ViewController = GameViewController
+    init(game: RPSGame) {
+        gameViewModel = GameViewModel(game: game)
+    }
+    let gameViewModel: GameViewModel
+    
+    func rootViewController() -> ViewController {
+        let vc = GameViewController(gameViewModel: gameViewModel)
+        return vc
+    }
+}

--- a/RPS-Game/Applications/Game/View/GameViewController.swift
+++ b/RPS-Game/Applications/Game/View/GameViewController.swift
@@ -10,13 +10,16 @@ import UIKit
 import Combine
 
 class GameViewController: UIViewController {
-    
+    convenience init(gameViewModel: GameViewModel) {
+        self.init()
+        self.gameViewModel = gameViewModel
+    }
     // MARK: Properties
     private var gameView: GameView? {
         view as? GameView
     }
     
-    private var gameViewModel: GameViewModel?
+    var gameViewModel: GameViewModel!
     private var subscriptions: Set<AnyCancellable> = []
     
     // MARK: Lifecycle
@@ -41,8 +44,6 @@ class GameViewController: UIViewController {
     }
     
     private func setupViewModel() {
-        let game = RPSGame()
-        gameViewModel = GameViewModel(game: game)
         guard let gameView = gameView else { return }
         gameViewModel?.$message
             .assign(to: \.messageLabel.text, on: gameView)

--- a/RPS-Game/Applications/Main/SceneDelegate.swift
+++ b/RPS-Game/Applications/Main/SceneDelegate.swift
@@ -18,7 +18,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        let vc = GameViewController()
+        let gameMVCFactory = GameComposition(game: RPSGame())
+        let vc = gameMVCFactory.rootViewController()
         let nav = UINavigationController(rootViewController: vc)
         window = UIWindow(windowScene: windowScene)
         window?.rootViewController = nav


### PR DESCRIPTION
在原本的 ViewController 中，建立了一個 ViewModel，會導致 ViewModel 在測試上抽換的困難。改動為使用 DI 後，ViewController 不在負責建立 ViewModel 了。 而由於 DI 的關係 `SceneDelegate` 開始肥大，因此使用 Composition root 作為 SOLID 的 S 實踐。